### PR TITLE
Fix for non-empty structs

### DIFF
--- a/ztapi/member.go
+++ b/ztapi/member.go
@@ -3,6 +3,7 @@
 package ztapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"strconv"
@@ -56,7 +57,7 @@ type Member struct {
 			Ts int
 		}
 		Authorized           bool
-		Capabilities         []string
+		Capabilities         []json.RawMessage
 		CreationTime         apiTime
 		ID                   string
 		Identity             string
@@ -68,7 +69,7 @@ type Member struct {
 		Objtype              string
 		PhysicalAddr         string
 		Revision             int
-		Tags                 []string
+		Tags                 []json.RawMessage
 		VMajor               int
 		VMinor               int
 		VProto               int

--- a/ztapi/network.go
+++ b/ztapi/network.go
@@ -2,7 +2,10 @@
 
 package ztapi
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // GetNetworkInfo returns a Nework containing information about a ZeroTier network
 func GetNetworkInfo(API, host, networkID string) (*Network, error) {
@@ -32,7 +35,7 @@ type Network struct {
 	Config struct {
 		ActiveMemberCount     int
 		AuthorizedMemberCount int
-		Capabilities          []string
+		Capabilities          []json.RawMessage
 		Clock                 apiTime
 		CreationTime          apiTime
 		EnableBroadcast       bool
@@ -57,7 +60,7 @@ type Network struct {
 			Or        bool
 			Type      string
 		}
-		Tags             []string
+		Tags             []json.RawMessage
 		TotalMemberCount int
 		V4AssignMode     struct {
 			Zt bool
@@ -79,6 +82,6 @@ type Network struct {
 	}
 	OnlineMemberCount int
 	CapabilitesByName map[string]string
-	TagsByName        map[string]string
+	TagsByName        map[string]json.RawMessage
 	CircuitTestEvery  int
 }


### PR DESCRIPTION
Capabilites, Tags and TagsByName fields can be non-empty structs when set in the ZeroTier UI. The current code breaks in that case (can't be unmarshaled) whereas the patch replaces `string` with `json.RawMessage` to take care of it. As the fields are not used for the DNS function, and since the contents of at least the Tags varies depending on what a users sets, I think its a legit approach to the problem.